### PR TITLE
fix: reuse default credential provider across signed requests

### DIFF
--- a/.changeset/lucky-pianos-wander.md
+++ b/.changeset/lucky-pianos-wander.md
@@ -1,0 +1,12 @@
+---
+'aws-sigv4-fetch': minor
+'aws-sigv4-sign': minor
+---
+
+Reuse the default credential provider across requests
+
+When no `credentials` option is passed, the default provider from `@aws-sdk/credential-provider-node` was constructed on every signed request. The AWS SDK caches resolved credentials per provider instance, so a fresh instance per request never hit that cache: every request re-resolved credentials from scratch (shared config files, web identity token exchange, or the instance metadata service) and allocated new HTTP resources to do so. In long-running processes those accumulated, and under load the added latency was significant.
+
+The provider is now constructed once and reused. The pending construction is cached, so concurrent first requests share a single instance, and a failed construction is not cached so the next call can retry.
+
+**Behavior change:** the provider is pinned for the lifetime of the process, so changes to `AWS_PROFILE` or the other credential environment variables after the first signed request are no longer picked up. Pass `credentials` explicitly to switch identities at runtime. Credential _refresh_ is unaffected: the SDK still refreshes before expiry.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Credentials are **optional**. When omitted, they are resolved from the environme
 const signedFetch = createSignedFetcher({ service: 'lambda', region: 'eu-west-1' });
 ```
 
+The provider is constructed once and reused for the lifetime of the process. The AWS SDK caches the credentials it resolves and refreshes them before they expire, so only the first signed request pays for the lookup. Because the provider is pinned, changes to `AWS_PROFILE` or the other credential environment variables after the first signed request are not picked up; pass `credentials` explicitly if you need to switch identities at runtime.
+
 You can always pass them explicitly, which skips the lookup:
 
 ```ts

--- a/packages/aws-sigv4-sign/src/credential-provider.test.ts
+++ b/packages/aws-sigv4-sign/src/credential-provider.test.ts
@@ -1,19 +1,31 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { getDefaultCredentialProvider } from './credential-provider.js';
-import { credentials } from './fixtures.js';
+import { credentials, region, service, url } from './fixtures.js';
 
-vi.mock('@aws-sdk/credential-provider-node', async () => {
-  return {
-    defaultProvider: vi.fn().mockReturnValue(() => Promise.resolve(credentials)),
-  };
-});
+const { mockDefaultProvider } = vi.hoisted(() => ({
+  mockDefaultProvider: vi.fn(),
+}));
+
+vi.mock(import('@aws-sdk/credential-provider-node'), () => ({
+  defaultProvider: mockDefaultProvider,
+}));
 
 const originalWindow = global.window;
 const originalDocument = global.document;
 
+/**
+ * The default provider is cached at module scope, so the module registry has to
+ * be reset between tests to keep them isolated.
+ */
+async function importCredentialProvider() {
+  vi.resetModules();
+  return import('./credential-provider.js');
+}
+
 beforeEach(() => {
   global.window = undefined as any;
   global.document = undefined as any;
+  mockDefaultProvider.mockReset();
+  mockDefaultProvider.mockReturnValue(() => Promise.resolve(credentials));
 
   return () => {
     global.window = originalWindow;
@@ -24,6 +36,7 @@ beforeEach(() => {
 describe('getDefaultCredentialProvider', () => {
   it('should load default credentials provider in node environment', async () => {
     // Arrange
+    const { getDefaultCredentialProvider } = await importCredentialProvider();
 
     // Act
     const defaultCredentialProvider = await getDefaultCredentialProvider();
@@ -35,6 +48,7 @@ describe('getDefaultCredentialProvider', () => {
 
   it('should throw error when in browser environment', async () => {
     // Arrange
+    const { getDefaultCredentialProvider } = await importCredentialProvider();
     global.window = {} as any;
     global.document = {} as any;
 
@@ -43,5 +57,70 @@ describe('getDefaultCredentialProvider', () => {
 
     // Assert
     await expect(result).rejects.toThrow('AWS credentials provider is not available in browser environments');
+  });
+
+  it('should construct the provider once across sequential calls', async () => {
+    // Arrange
+    const { getDefaultCredentialProvider } = await importCredentialProvider();
+
+    // Act
+    const first = await getDefaultCredentialProvider();
+    const second = await getDefaultCredentialProvider();
+    const third = await getDefaultCredentialProvider();
+
+    // Assert
+    expect(mockDefaultProvider.mock.calls.length).toBe(1);
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+  });
+
+  it('should construct the provider once across concurrent calls', async () => {
+    // Arrange
+    const { getDefaultCredentialProvider } = await importCredentialProvider();
+
+    // Act
+    const providers = await Promise.all([
+      getDefaultCredentialProvider(),
+      getDefaultCredentialProvider(),
+      getDefaultCredentialProvider(),
+    ]);
+
+    // Assert
+    expect(mockDefaultProvider.mock.calls.length).toBe(1);
+    expect(providers[1]).toBe(providers[0]);
+    expect(providers[2]).toBe(providers[0]);
+  });
+
+  it('should not cache a failed construction', async () => {
+    // Arrange
+    const { getDefaultCredentialProvider } = await importCredentialProvider();
+    mockDefaultProvider.mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+
+    // Act
+    const failed = getDefaultCredentialProvider();
+    await expect(failed).rejects.toThrow('AWS credentials provider could not be loaded');
+    const recovered = await getDefaultCredentialProvider();
+
+    // Assert
+    expect(mockDefaultProvider.mock.calls.length).toBe(2);
+    expect(await recovered()).toEqual(credentials);
+  });
+});
+
+describe('signRequest without explicit credentials', () => {
+  it('should construct the provider once across multiple signs', async () => {
+    // Arrange
+    vi.resetModules();
+    const { signRequest } = await import('./sign-request.js');
+
+    // Act
+    for (let i = 0; i < 5; i++) {
+      await signRequest(url, { service, region });
+    }
+
+    // Assert
+    expect(mockDefaultProvider.mock.calls.length).toBe(1);
   });
 });

--- a/packages/aws-sigv4-sign/src/credential-provider.ts
+++ b/packages/aws-sigv4-sign/src/credential-provider.ts
@@ -8,17 +8,15 @@ function isBrowser(): boolean {
 }
 
 /**
- * Returns the default credential provider based on the environment.
- * In Node.js, it uses the default provider from @aws-sdk/credential-provider-node.
- * In a browser environment, it throws an error as credentials must be provided explicitly.
+ * The pending or resolved default credential provider.
+ *
+ * The promise is cached rather than the provider it resolves to, so that
+ * concurrent callers all await the same construction and exactly one provider
+ * instance is ever built.
  */
-export async function getDefaultCredentialProvider(): Promise<AwsCredentialIdentityProvider> {
-  if (isBrowser())
-    throw new Error(
-      'AWS credentials provider is not available in browser environments. ' +
-        'You must provide credentials explicitly when calling signRequest in a browser.',
-    );
+let cachedDefaultProvider: Promise<AwsCredentialIdentityProvider> | undefined;
 
+async function loadDefaultCredentialProvider(): Promise<AwsCredentialIdentityProvider> {
   try {
     // Dynamic import to prevent bundling Node.js specific code in browser bundles
     const { defaultProvider } = await import('@aws-sdk/credential-provider-node');
@@ -29,4 +27,32 @@ export async function getDefaultCredentialProvider(): Promise<AwsCredentialIdent
       cause: error,
     });
   }
+}
+
+/**
+ * Returns the default credential provider based on the environment.
+ * In Node.js, it uses the default provider from @aws-sdk/credential-provider-node.
+ * In a browser environment, it throws an error as credentials must be provided explicitly.
+ *
+ * The provider is constructed once and reused for the lifetime of the process.
+ * The AWS SDK caches resolved credentials per provider instance and refreshes
+ * them before they expire, so reusing one instance avoids re-resolving
+ * credentials (and leaking the HTTP resources used to fetch them) on every call.
+ */
+export async function getDefaultCredentialProvider(): Promise<AwsCredentialIdentityProvider> {
+  if (isBrowser())
+    throw new Error(
+      `AWS credentials provider is not available in browser environments. You must provide credentials explicitly when calling signRequest in a browser.`,
+    );
+
+  if (!cachedDefaultProvider) {
+    cachedDefaultProvider = loadDefaultCredentialProvider();
+
+    // A transient failure must not be cached permanently, so the next call can retry
+    cachedDefaultProvider.catch(() => {
+      cachedDefaultProvider = undefined;
+    });
+  }
+
+  return cachedDefaultProvider;
 }


### PR DESCRIPTION
## Summary

- Fixes #40. Without an explicit `credentials` option, `defaultProvider()` was constructed on **every** signed request. The AWS SDK memoizes resolved credentials in a closure that is private to each provider instance, so a fresh instance per request never hit that cache: every request re-resolved credentials (shared config files, web identity token exchange, or IMDS) and allocated new HTTP resources to do so. Reusing the fetcher did not help, since `createSignedFetcher` captures `options.credentials` (`undefined`) once and the provider was rebuilt deeper in the call stack on each sign.
- `getDefaultCredentialProvider` now caches the **promise** at module scope rather than the resolved provider. The assignment happens before the first `await`, so concurrent first callers all await the same construction and exactly one instance is ever built. Caching the resolved provider instead would leave a window where parallel first calls each build their own.
- A failed construction is not cached: a `.catch()` clears the cache so the next call can retry rather than making a transient import failure permanent.
- The browser guard stays ahead of the cache read, so a populated cache cannot mask it, and the function stays `async` so that error still rejects rather than throwing synchronously.
- Documented the behavior in the README, since pinning the provider for the process lifetime is an observable semantic change: `AWS_PROFILE` and the other credential environment variables are no longer re-read after the first signed request. Credential *refresh* is unaffected, as the SDK still refreshes before expiry.

Changeset is `minor` for both packages rather than `patch`, on the grounds that the pinning semantics are more than a pure bugfix. Happy to downgrade if you'd rather ship it as one.

## Test plan

- [x] `pnpm test:unit` — 75 tests pass
- [x] Three new cases verified to fail without the source change (confirmed by stashing only `credential-provider.ts`): provider constructed once across sequential calls, across concurrent calls, and across 5 `signRequest` calls with no explicit `credentials`
- [x] A fourth case guards the failure path: a throwing construction rejects, is not cached, and the next call succeeds
- [x] Pre-existing tests still pass, including the browser-environment rejection and `should use default node credentials provider`
- [x] `pnpm typecheck`, `pnpm lint:ci`, `pnpm format:ci`, `pnpm build` all clean
- [ ] `pnpm test:e2e` not run locally (signs real requests against AWS)

Test isolation uses `vi.resetModules()` plus dynamic imports, since the cache is module-global. That avoids exporting a reset helper into the public API, which #40 had raised as a possible requirement.